### PR TITLE
9081 단어맞추기, 16234 인구이동 (혜안)

### DIFF
--- a/2022/Mar/week_4/boj_16234_인구이동_경혜안.java
+++ b/2022/Mar/week_4/boj_16234_인구이동_경혜안.java
@@ -1,0 +1,105 @@
+package Mar;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class boj_16234_인구이동_경혜안 {
+	static int N, L, R;
+	static int[][] country;
+	static boolean isStop;
+	public static void main(String[] args) throws IOException {
+		BufferedReader bf = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st;
+		
+		st = new StringTokenizer(bf.readLine());
+		
+		N = Integer.parseInt(st.nextToken());
+		L = Integer.parseInt(st.nextToken());
+		R = Integer.parseInt(st.nextToken());
+		
+		country = new int[N][N];
+		
+		// 나라 별 인구 입력 
+		for (int i = 0; i < N; i++) {
+			st = new StringTokenizer(bf.readLine());
+			for (int j = 0; j < N; j++) {
+				country[i][j] = Integer.parseInt(st.nextToken());
+			}
+		}
+		
+		int cnt = 0;
+		while(true) {
+			isStop = true;
+			boolean[][] visited = new boolean[N][N];
+			for (int i = 0; i < N; i++) {
+				for (int j = 0; j < N; j++) {
+					if(!visited[i][j]) BFS(i, j, visited);
+				}
+			}
+			
+			if(isStop) break;
+			cnt++;
+		}
+		System.out.println(cnt);
+	}
+	
+	static void BFS(int x, int y, boolean[][] visited) {
+		ArrayList<int[]> change = new ArrayList<int[]>();
+		int[] dx = {0, -1, 0, 1}, dy = {-1, 0, 1, 0};
+		Queue<int[]> queue = new LinkedList<int[]>();
+		
+		queue.offer(new int[] {x, y});
+		
+		
+		visited[x][y] = true;
+		int popul = 0; 
+		int cnt = 0;
+		while(!queue.isEmpty()) {
+			int[] cur = queue.poll();
+			popul += country[cur[0]][cur[1]];
+			cnt++;
+			change.add(cur);
+			for (int i = 0; i < 4; i++) {
+				int posX = cur[0] + dx[i];
+				int posY = cur[1] + dy[i];
+				
+				if(isValid(posX, posY) && !visited[posX][posY] 
+						&& isRange(Math.abs(country[cur[0]][cur[1]] - country[posX][posY]))) {
+					visited[posX][posY] = true;
+					queue.offer(new int[] {posX, posY});
+				}
+			}
+		}
+		
+		if(cnt > 1) {
+			move(change, popul, cnt);
+			isStop = false;
+		}
+		
+	}
+	
+	static boolean isValid(int x, int y) {
+		if(x >= 0 && x < N && y >= 0 && y < N) return true;
+		return false;
+	}
+	
+	static boolean isRange(int p) {
+		if(p >= L && p <= R) return true;
+		return false;
+	}
+	
+	static void move(ArrayList<int[]> change, int popul, int cnt) {
+		
+		int newPopul = popul / cnt;
+		
+		for (int[] is : change) {
+			country[is[0]][is[1]] = newPopul;
+		}
+	}
+
+}

--- a/2022/Mar/week_4/boj_9081_단어맞추기_경혜안.java
+++ b/2022/Mar/week_4/boj_9081_단어맞추기_경혜안.java
@@ -1,0 +1,69 @@
+package Mar;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class boj_9081_단어맞추기_경혜안 {
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		BufferedReader bf = new BufferedReader(new InputStreamReader(System.in));
+		int t = Integer.parseInt(bf.readLine());
+		
+		for (int i = 0; i < t; i++) {
+			String str = bf.readLine();
+			int len = str.length();
+			int[] alpha = new int[26];
+			int idx = str.charAt(len-1) - 'A'; // 비교 기준 문자 
+			alpha[idx]++;
+			int breakPoint = -1;
+			int breakIdx = -1;
+			for (int j = len-2; j >= 0 ; j--) {
+				int cur = str.charAt(j) - 'A';
+				alpha[cur]++;
+				if(cur < idx) {
+					breakPoint = cur;
+					breakIdx = j;
+					break;
+				}
+				idx = cur;
+			}
+			if(breakPoint == -1) {
+				System.out.println(str);
+				continue;
+			}
+			
+			String answer = "";
+			
+			// 바뀐 포인트 이 전의 문자들은 그대로 저장 
+			for (int j = 0; j < breakIdx; j++) {
+				answer += str.charAt(j);
+			}
+			
+			// 바뀐 포인트보다 바로 다음 큰 문자 저장 
+			for (int j = breakPoint+1; j < 26; j++) {
+				if(alpha[j] > 0) {
+					alpha[j]--;
+					answer += (char)('A' + j);
+					break;
+				}
+			}
+			
+			for (int j = 0; j < 26; j++) {
+				while(alpha[j] > 0) {
+					alpha[j]--;
+					answer += (char)('A'+j);
+				}
+			}
+			
+			System.out.println(answer);
+			
+			
+			
+			
+			
+		}
+
+	}
+	
+}
+


### PR DESCRIPTION
### 📕 Problem

[백준 9081_단어맞추기](https://www.acmicpc.net/problem/9081)  

### 📗 Idea & Algorithm

초기 문자열의 단어 순서를 비교하고 
그 다음으로 큰 숫자배열을 찾는 방식으로 진행했습니다.

### 📘 Comment
처음에 조합+ 정렬로 냅다 풀었는데 메모리 초과가 났습니다 😢
효율적으로 알고리즘을 생각하는 방법을 배울 수 있어서 좋았던 문제인것 같아요.
---

### 📕 Problem

[백준 16234_인구이동](https://www.acmicpc.net/problem/16234)  

### 📗 Idea & Algorithm
BFS를 이용하여 인접한 나라간의 이동이 가능한 나라를 확인하였고, 동시에 인접한 나라와 인구 수를 갱신했습니다. 
이후 변화한 나라만 인구수를 새롭게 갱신해주는 방식으로 풀었습니다. 

### 📘 Comment

별 생각없이 boolean배열을 이용해서 모든 나라를 체크하며 인구 수를 변경해줬더니 80%에서 계속 시간 초과가 났습니다. 
이 후에 바뀐 나라만 인구수를 변경해줬더니 풀렸어요 🥵
급 스타트업 인턴 시절에 비효율적인 코딩을 할때마다 "학교에서는 몰라도 회사에서는 코드 효율성이 곧 돈이에요" 하고 혼나던 기억이 새록새록 났읍니다 ^^.... 
교훈 : 푸는것에 급급하지 말고, 효율적인 알고리즘을 생각하며 풀자 ! 나는 코딩생이다! 

