### PR TITLE
9081 단어맞추기, 16234 인구이동 (늘이)

### DIFF
--- a/2022/Mar/week_4/boj_16234_인구이동_하늘이.swift
+++ b/2022/Mar/week_4/boj_16234_인구이동_하늘이.swift
@@ -1,0 +1,110 @@
+//
+//  main.swift
+//  16234_인구 이동
+//
+//  Created by 하늘이 on 2022/03/19.
+//
+
+import Foundation
+
+// input
+var input = readLine()!.split(separator: " ").map{ Int($0)! }
+
+let N = input[0]
+let L = input[1]
+let R = input[2]
+
+// 인구수, bfs 방문여부, 결과값
+var landPeople = Array(repeating: Array(repeating: 0, count: N), count: N)
+var visited = Array(repeating: Array(repeating: false, count: N), count: N)
+var movePeopleDay = 0
+
+// input
+for i in 0..<N {
+    input = readLine()!.split(separator: " ").map{ Int($0)! }
+    for j in 0..<N {
+        landPeople[i][j] = input[j]
+    }
+}
+
+let dr = [-1, 1, 0, 0]
+let dc = [0, 0, -1, 1]
+
+func isIn(_ r: Int, _ c: Int) -> Bool {
+    return 0<=r && r<N && 0<=c && c<N
+}
+
+// 두 나라의 인구 차이가 L명 이상, R명 이하
+func isOpenBorderLine(_ countryA: (Int, Int), _ countryB: (Int, Int)) -> Bool {
+    let diff = abs(landPeople[countryA.0][countryA.1] - landPeople[countryB.0][countryB.1])
+    return L <= diff && diff <= R
+}
+
+// 인구 이동이 일어날 수 있는지 여부
+func isMovePeople() -> Bool {
+    var nr = 0, nc = 0
+    for i in 0..<N {
+        for j in 0..<N {
+            for k in 0..<4 {
+                nr = i + dr[k]
+                nc = j + dc[k]
+                if isIn(nr, nc) && isOpenBorderLine((i, j), (nr, nc)) {
+                    return true
+                }
+            }
+        }
+    }
+    return false
+}
+
+// 국경선이 아직 안열린 곳에서만 bfs
+func openBorderLine(_ startR: Int, _ startC: Int) {
+    // queue 인척하는 배열
+    var queue: [(Int, Int)] = []
+    // 위치, 인구 수 저장
+    var union: [(Int, Int)] = []
+    
+    visited[startR][startC] = true
+    queue.append((startR, startC))
+    union.append((startR, startC))
+    
+    while !queue.isEmpty {
+        let r = queue.first!.0
+        let c = queue.first!.1
+        queue.removeFirst()
+    
+        for i in 0..<4 {
+            let nr = r + dr[i]
+            let nc = c + dc[i]
+        
+            if isIn(nr, nc) && !visited[nr][nc] && isOpenBorderLine((r, c), (nr, nc)) {
+                visited[nr][nc] = true
+                queue.append((nr, nc))
+                union.append((nr, nc))
+            }
+        }
+    }
+    
+    // 각 칸의 인구수
+    let unionPeopleCount = union.reduce(0, { $0 + landPeople[$1.0][$1.1] }) / union.count
+    // 연합의 인구수 바꾸기
+    for country in union {
+        landPeople[country.0][country.1] = unionPeopleCount
+    }
+}
+
+// main
+
+while isMovePeople() {
+    visited = Array(repeating: Array(repeating: false, count: N), count: N)
+    for i in 0..<N {
+        for j in 0..<N {
+            if !visited[i][j] {
+                openBorderLine(i, j)
+            }
+        }
+    }
+    movePeopleDay += 1
+}
+
+print(movePeopleDay)

--- a/2022/Mar/week_4/boj_9081_단어맞추기_하늘이.swift
+++ b/2022/Mar/week_4/boj_9081_단어맞추기_하늘이.swift
@@ -1,0 +1,85 @@
+//
+//  main.swift
+//  9081_단어 맞추기
+//
+//  Created by 하늘이 on 2022/03/16.
+//
+
+import Foundation
+
+let T = Int(readLine()!)!
+
+for _ in 0..<T {
+    
+    // next-permutation
+    // 단어를 받고 reverse -> 앞에서부터 찾으려고
+    var word = Array(readLine()!.reversed())
+    // next-permutation 에서 word[i-1] < word[[i] 가 되는 가장 큰 값
+    var top = -1
+    
+    // top 값 찾기
+    for index in 0..<word.count {
+        // 만약 찾는 값 없이 맨 앞에 도달했다면 이미 word가 마지막 순열 값
+        if index == word.count - 1 {
+            break
+        }
+        
+        if word[index + 1] < word[index] {
+            top = index
+            break
+        }
+    }
+    
+    // 처음 word 값 출력
+    if top == -1 {
+        print(word.reversed().reduce("", { String($0) + String($1) }))
+        continue
+    }
+    
+    // top 값 뒤에 있는 (revere라서 앞에 있는) 값 중 top + 1의 값보다 큰 값 찾기
+    for index in 0..<word.count {
+        // index가 top보다 커질 경우를 고려할 필요가 없다.
+        if word[top + 1] < word[index] {
+            word.swapAt(top + 1, index)
+            break
+        }
+    }
+    
+    // 원래 순서로
+    word = word.reversed()
+    
+    top = word.count - top - 1
+    let frontWord: String = word[..<top].reduce("", {String($0) + String($1)})
+    // top 뒤의 값은 오름차순으로 정렬
+    let backWord: String = word[top...].sorted(by: <).reduce("", {String($0) + String($1)})
+    print(frontWord + backWord)
+}
+
+
+/// 참조코드
+//import Foundation
+//
+//let n = Int(readLine()!)!
+//
+//for _ in 0..<n {
+//    var word = readLine()!.map{String($0)}
+//    if nextPermutation(&word) {print(word.joined())}
+//    else{ print(word.joined()) }
+//}
+//
+//func nextPermutation(_ word:inout [String]) -> Bool{
+//    var i = word.count - 1
+//    while i > 0 && word[i-1] >= word[i] { i -= 1 }
+//    if i == 0 { return false}
+//
+//    var j = word.count - 1
+//    while word[i-1] >= word[j] { j -= 1 }
+//
+//    var temp = word[i-1]
+//    word[i-1] = word[j]
+//    word[j] = temp
+//
+//    word = word[..<i] + word[i...].reversed()
+//
+//    return true
+//}


### PR DESCRIPTION
### 📕 Problem

[백준 16234_인구 이동](https://www.acmicpc.net/problem/16234)  

### 📗 Idea & Algorithm

인구수 이차원 배열로 두고 bfs로 돌아가면서 연합이 된 나라들 인구수를 바꿔줬어요
인구이동이 더이상 일어나지 않을 때까지 조건을 어떻게 구현할지 생각하다가 
그냥 전체 나라 돌면서 인접한 나라랑 이동이 일어나는지 체크했는데 더 좋은 방법이 있지 않을까요..!

### 📘 Comment

reduce 사용해봤는데 편하고 좋은거같아요

---

### 📕 Problem

[백준 9081_단어 맞추기](https://www.acmicpc.net/problem/9081)  

### 📗 Idea & Algorithm

next permutation 한번 돌려서 다음 조합 구하는 방법으로 풀었어요
더 깔끔하게 while로 푸는 방법이 있지만 직관적으로 제가 알아보기 쉬우려고 for문 돌렸습니다..ㅎ0ㅎ
Swift에서는 뒤에서 돌려면 코드를 더 적어야해서 reverse 해서 코드 돌렸어요
[블로그!](https://luen.tistory.com/163)

### 📘 Comment

냅다 조합으로 풀다가 저는 시간초과가..ㅎ
조합 푸는 방법 하나 더 있는거 풀면서 깨달았어요.. next permutation이 재귀인줄..ㅎ 